### PR TITLE
修复：第一次显示随机面板生成随机属性

### DIFF
--- a/jyx2/Assets/Scripts/Jyx2UIScripts/GameMainMenu.cs
+++ b/jyx2/Assets/Scripts/Jyx2UIScripts/GameMainMenu.cs
@@ -73,6 +73,9 @@ public partial class GameMainMenu : Jyx2_UIBase {
         this.InputNamePanel_RectTransform.gameObject.SetActive(false);
         this.StartNewRolePanel_RectTransform.gameObject.SetActive(true);
         m_randomProperty.ShowComponent();
+		// generate random property at randomP panel first show
+		// added by eaphone at 2021/05/23
+        OnCreateRoleNoClick();
     }
     
     void OnNewGame()


### PR DESCRIPTION
开始新游戏显示属性面板时，生成随机属性