### PR TITLE
修复BuildAssetBundle和打包的时候，因为代码编译错误导致的中断

### DIFF
--- a/jyx2/Assets/Scripts/Jyx2Model/ModelAsset.cs
+++ b/jyx2/Assets/Scripts/Jyx2Model/ModelAsset.cs
@@ -9,10 +9,11 @@ using Hanjiasongshu.ThreeD.XML;
 using HanSquirrel.ResourceManager;
 using HSFrameWork.ConfigTable;
 using Sirenix.OdinInspector;
-using Sirenix.OdinInspector.Editor;
 using Sirenix.Utilities;
+#if UNITY_EDITOR
 using UnityEditor;
 using UnityEditor.SceneManagement;
+#endif
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using Debug = UnityEngine.Debug;
@@ -240,6 +241,7 @@ namespace Jyx2
             m_OffsetScale = Vector3.one;
         }
 
+        #if UNITY_EDITOR
         private void LoadDefaultView()
         {
             switch (m_Id)
@@ -263,6 +265,7 @@ namespace Jyx2
             
             AssetDatabase.SaveAssets();
         }
+        #endif
     }
     
     [SerializeField]


### PR DESCRIPTION
修复BuildAssetBundle和打包的时候，因为代码编译错误导致的中断