### PR TITLE
修复：角色可隔着墙壁与物品/人物交互

### DIFF
--- a/jyx2/Assets/3DScene/Model/Common/Buildings/Wall/Wall_23_1.prefab
+++ b/jyx2/Assets/3DScene/Model/Common/Buildings/Wall/Wall_23_1.prefab
@@ -11,12 +11,13 @@ GameObject:
   - component: {fileID: 7569779945515227012}
   - component: {fileID: 7569779945518127012}
   - component: {fileID: 7569779945516995940}
+  - component: {fileID: 2672601348456040244}
   m_Layer: 0
   m_Name: Wall_23_1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
+  m_StaticEditorFlags: 8
   m_IsActive: 1
 --- !u!4 &7569779945515227012
 Transform:
@@ -27,7 +28,7 @@ Transform:
   m_GameObject: {fileID: 7569779945514732452}
   m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: -1.3783722, y: 3.9919424, z: -0.37481308}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 0.75929, y: 0.75929046, z: 0.75929046}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -54,6 +55,8 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -65,6 +68,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -77,3 +81,17 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &2672601348456040244
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7569779945514732452}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.19774848, y: 1.8655257, z: 3.7419593}
+  m_Center: {x: 0.0000009536743, y: -0.0000002384186, z: 1.8709791}

--- a/jyx2/Assets/3DScene/Model/Common/Buildings/Wall/Wall_23_2.prefab
+++ b/jyx2/Assets/3DScene/Model/Common/Buildings/Wall/Wall_23_2.prefab
@@ -11,12 +11,13 @@ GameObject:
   - component: {fileID: 6003032803240009459}
   - component: {fileID: 6003032803239206611}
   - component: {fileID: 6003032803238108179}
+  - component: {fileID: 4219856060665260326}
   m_Layer: 0
   m_Name: Wall_23_2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
+  m_NavMeshLayer: 1
+  m_StaticEditorFlags: 8
   m_IsActive: 1
 --- !u!4 &6003032803240009459
 Transform:
@@ -25,13 +26,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6003032803240100563}
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 1.7458801, y: 3.9919422, z: -4.9098587}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 0.75929, y: 0.75929, z: 0.75929}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: -90, y: 0, z: 0}
 --- !u!33 &6003032803239206611
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -54,6 +55,8 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -65,6 +68,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -77,3 +81,17 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &4219856060665260326
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6003032803240100563}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.19774848, y: 1.8655252, z: 3.7419584}
+  m_Center: {x: -0.000000040978193, y: 0.00000011920929, z: 1.8709804}

--- a/jyx2/Assets/3DScene/Model/Common/Buildings/Wall/Wall_23_3.prefab
+++ b/jyx2/Assets/3DScene/Model/Common/Buildings/Wall/Wall_23_3.prefab
@@ -17,7 +17,7 @@ GameObject:
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
+  m_StaticEditorFlags: 8
   m_IsActive: 1
 --- !u!4 &2251706251410532430
 Transform:
@@ -55,6 +55,8 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -66,6 +68,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -78,6 +81,7 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
 --- !u!65 &7409019048804896635
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -102,12 +106,13 @@ GameObject:
   - component: {fileID: 8005725509542525405}
   - component: {fileID: 8005725509543852541}
   - component: {fileID: 8005725509544950589}
+  - component: {fileID: 3454420257473889613}
   m_Layer: 0
   m_Name: Wall_23_3
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
+  m_StaticEditorFlags: 8
   m_IsActive: 1
 --- !u!4 &8005725509542525405
 Transform:
@@ -118,7 +123,7 @@ Transform:
   m_GameObject: {fileID: 8005725509542946301}
   m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
   m_LocalPosition: {x: 0.46888605, y: 3.9919417, z: -1.7851486}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 0.75929, y: 0.75929, z: 0.75929}
   m_Children:
   - {fileID: 2251706251410532430}
   m_Father: {fileID: 0}
@@ -146,6 +151,8 @@ MeshRenderer:
   m_MotionVectors: 1
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -157,6 +164,7 @@ MeshRenderer:
   m_ProbeAnchor: {fileID: 0}
   m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
   m_PreserveUVs: 0
   m_IgnoreNormalsForChartDetection: 0
   m_ImportantGI: 0
@@ -169,3 +177,17 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &3454420257473889613
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8005725509542946301}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.1977486, y: 1.8655266, z: 3.7419598}
+  m_Center: {x: -0.0000012330713, y: 0.000002534156, z: 1.8709807}

--- a/jyx2/Assets/Scripts/Jyx2GameMap/Jyx2Player.cs
+++ b/jyx2/Assets/Scripts/Jyx2GameMap/Jyx2Player.cs
@@ -187,18 +187,55 @@ public class Jyx2Player : MonoBehaviour
         {
             var target = targets[i];
 
-            //判断是否在视野内
-            if (Vector3.Angle(transform.forward, target.transform.position - transform.position) <= PLAYER_INTERACTIVE_ANGLE / 2)
+            if (CanSee(target) && SetInteractiveGameEvent(target))
             {
                 //找到第一个可交互的物体，则结束
-                if (SetInteractiveGameEvent(target))
-                {
-                    return target.GetComponent<GameEvent>();
-                }
+                return target.GetComponent<GameEvent>();
             }
         }
 
         return null;
+    }
+
+    bool CanSee(Collider target)
+    {
+
+        //判断是否在视野角度内
+        var isInViewField = Vector3.Angle(transform.forward, target.transform.position - transform.position) <= PLAYER_INTERACTIVE_ANGLE / 2;
+        if(isInViewField) {
+
+            var targetDirection = (target.transform.position - transform.position).normalized;
+
+            //判断主角的NavMesh Agent是否在目标trigger范围內
+            var isInTrigger = target.bounds.Contains(transform.position + targetDirection * _navMeshAgent.radius);
+            if(isInTrigger) 
+            {
+                Debug.DrawLine(transform.position, target.transform.position, Color.green);
+                Debug.Log("Inside trigger: " + target.transform.name);
+
+                return true;
+            }
+            else
+            {
+                //判断主角与目标之间有无其他collider遮挡。忽略trigger。
+                RaycastHit hit;
+                if(Physics.Raycast(transform.position, targetDirection, out hit, Mathf.Infinity, Physics.AllLayers, QueryTriggerInteraction.Ignore)) {
+                    Debug.Log("Hit. hit: " + hit.transform.name + " target:" + target.transform.name);
+                    if(hit.transform.GetInstanceID() != target.transform.GetInstanceID())
+                    {
+                        Debug.DrawLine(transform.position, hit.point, Color.red);
+                        return false;
+                    }
+                }
+                Debug.Log("Outside trigger: " + target.transform.name);
+                Debug.DrawLine(transform.position, target.transform.position, Color.green);
+                return true;
+
+            }
+        }
+
+
+        return false;
     }
 
     bool SetInteractiveGameEvent(Collider c)


### PR DESCRIPTION
修复：https://github.com/jynew/jynew/issues/405

# 解决方案

1. 搜索到可交互物体后，做视野检查。条件一，目标在可视角度内；条件二，角色的nevmesh agent在交互物体的trigger范围内，或者角色与目标之间没有碰撞体阻隔。
2. 为小虾米居内使用的墙体prefab增加碰撞体。

下图展示修复后的结果：
![Screen Shot 2021-09-08 at 5 26 51 pm](https://user-images.githubusercontent.com/782895/132516938-6f3807a6-dd07-4b69-861f-84372a8137d5.png)

目前仅为小虾米居的墙体增加了碰撞体，并没有对其他地图应用的墙体prefab做修改。如果在其他地图遇到相关问题，只需为墙体增加碰撞体。

# 已测试：
已在小虾米居以及河洛客栈测试过所有交互物体。

# 可能的改进方案：
可以通过Nav Mesh的边缘检测发现障碍物，例如`NavMeshAgent.Raycast`。其性能更好。但是经过测试，在目前的场景设置下，有些交互物体在Nav Mesh外：

![Screen Shot 2021-09-09 at 12 00 50 am](https://user-images.githubusercontent.com/782895/132524327-211427ef-63e5-4dcf-9ce5-7ccfe466fa38.png)

![Screen Shot 2021-09-08 at 11 59 23 pm](https://user-images.githubusercontent.com/782895/132524293-5e838ae4-aad1-4963-b3e7-d58d1a18a85f.png)
