### PR TITLE
修正8d688ac删除空文件引起的#492的问题

### DIFF
--- a/jyx2/Assets/Prefabs/Jyx2UI/GameMainMenu.prefab
+++ b/jyx2/Assets/Prefabs/Jyx2UI/GameMainMenu.prefab
@@ -2702,7 +2702,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 4047244980026936082}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e77055bee89902d4bba6ef82a8f4680f, type: 3}
+  m_Script: {fileID: 11500000, guid: 6c06cffd40a618d4faed82f0f5918d1a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &4047244980034396824


### PR DESCRIPTION
close #492 
主界面创建角色页面，点击确定按钮会报错。键盘操作正常。