### PR TITLE
添加了Mesh的合并脚本，让相同材质的网格能够合并在一起渲染，减少Draw Call。

### DIFF
--- a/jyx2/Assets/Scripts/MeshCombiner.cs
+++ b/jyx2/Assets/Scripts/MeshCombiner.cs
@@ -1,0 +1,65 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class MeshCombiner : MonoBehaviour
+{
+    List<GameObject> originObjects;
+    // Start is called before the first frame update
+    void Start()
+    {
+        originObjects = new List<GameObject>();
+        List<CombineInstance> combineInstances = new List<CombineInstance>();
+        MeshFilter[] meshFilters = transform.GetComponentsInChildren<MeshFilter>();
+        foreach (MeshFilter meshFilter in meshFilters)
+        {
+            // TODO ：可添加一些筛选
+            originObjects.Add(meshFilter.gameObject);
+            for (int sub = 0; sub < meshFilter.sharedMesh.subMeshCount; sub++)
+            {
+                CombineInstance ci = new CombineInstance();
+                ci.mesh = meshFilter.sharedMesh;
+                ci.subMeshIndex = sub;
+                ci.transform = meshFilter.transform.localToWorldMatrix;
+                combineInstances.Add(ci);
+            }
+        }
+
+        GameObject combinedObject = new GameObject();
+        combinedObject.transform.parent = transform;
+        combinedObject.transform.position = Vector3.zero;
+        combinedObject.name = "Combined Render Object(Generated)";
+
+        MeshFilter tempFilter = combinedObject.GetComponent<MeshFilter>();
+        if (!tempFilter)
+        {
+            tempFilter = combinedObject.AddComponent<MeshFilter>();
+        }
+
+        tempFilter.sharedMesh = new Mesh();
+
+        // 合并网格
+        tempFilter.sharedMesh.CombineMeshes(combineInstances.ToArray(), true, true);
+
+        MeshRenderer tempRenderer = combinedObject.GetComponent<MeshRenderer>();
+        if (!tempRenderer)
+        {
+            tempRenderer = combinedObject.AddComponent<MeshRenderer>();
+        }
+
+        MeshRenderer meshRenderer = transform.GetComponentInChildren<MeshRenderer>();
+
+        tempRenderer.sharedMaterial = meshRenderer.sharedMaterial;
+
+        for(int i = 0; i < originObjects.Count; i++)
+        {
+            originObjects[i].GetComponent<MeshRenderer>().enabled = false;
+        }
+    }
+
+    void OnDestroy()
+    {
+        originObjects.Clear();
+    }
+
+}

--- a/jyx2/Assets/Scripts/MeshCombiner.cs.meta
+++ b/jyx2/Assets/Scripts/MeshCombiner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6d40b6985c187d54d8868703a53c49bf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
我在查看小虾米居场景的时候发现Draw call快接近600，感觉这样小规模的场景有点奇怪，或许在移动端(中低配)上会有影响。
细看发现原因在于细碎的物体，尤其是静态的简单网格，没有合并到一起，大量的小物体渲染造成了较大的命令开销。
**建议在场景搭建时，静态物体如墙壁、杂物，都预先合并成一整个网格。或者贴附上这个脚本，让它们在运行开始时合并，以减少命令开销。**
具体测试：
合并墙壁，因为墙壁都在Wall这个对象下，就将脚本Mesh Combiner贴附在Wall上。这个脚本对于要合并的网格需要开启读写。
![2L1Mesh](https://user-images.githubusercontent.com/41277740/145173815-cdcc3c54-d2d4-4fbb-8781-04174e70dc6c.png)
![2LnMesh](https://user-images.githubusercontent.com/41277740/145174160-fb06ac8d-9e4a-48c6-83cb-c36b99178199.png)
测试下来Draw Call 减少205，SetPass calls减少73。三角数因为对原网格没做处理所以有了一点增加。因为我是在editor中测试，帧数可能没什么参考意义，建议在实机测试一下。