### PR TITLE
推荐将Outline的外扩改到NDC空间，避免近大远小的效果。

### DIFF
--- a/jyx2/Assets/3rd/_MK/MKToonFree/Shader/Inc/Outline/MKToonOutlineOnlyBase.cginc
+++ b/jyx2/Assets/3rd/_MK/MKToonFree/Shader/Inc/Outline/MKToonOutlineOnlyBase.cginc
@@ -12,8 +12,11 @@
 		UNITY_TRANSFER_INSTANCE_ID(v,o);
 		UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
 
-		v.vertex.xyz += normalize(v.normal) * _OutlineSize;
+		//v.vertex.xyz += normalize(v.normal) * _OutlineSize;
 		o.pos = UnityObjectToClipPos(v.vertex);
+		float3 viewNormal = mul((float3x3)UNITY_MATRIX_IT_MV, normalize(v.normal));
+		float3 ndcNormal = mul((float3x3)UNITY_MATRIX_P, normalize(viewNormal)) * o.pos.w; //变换法线到ndc空间
+		o.pos.xy += 0.01 * _OutlineSize * ndcNormal.xy * 8; //8是新旧效果的大概参数倍率， 免去重新调参
 		o.color = _OutlineColor;
 
 		UNITY_TRANSFER_FOG(o,o.pos);


### PR DESCRIPTION
项目中的轮廓线shader简单地在模型空间沿法线进行外扩，这会出现近大远小的的效果：在远处效果合适的情况下，镜头拉近就会发现很突兀的背面黑线。
改到NDC空间会改善这样的问题，变得自适应一些，测试如下：
模型空间（原方法）
![模型空间](https://user-images.githubusercontent.com/41277740/145574225-201664c2-26bd-4a06-abb9-e3467318908b.gif)
NDC空间
![NDC空间](https://user-images.githubusercontent.com/41277740/145574307-369f65fa-ee4e-4aea-bfef-4371ca3f596d.gif)
两种方法会有参数效果上的不统一，我大概乘了一个系数8，使看上去差不多，可以不再重复调动outline参数。
