### PR TITLE
技能测试场景中模型更换的一些UI逻辑修复

### DIFF
--- a/jyx2/Assets/Scripts/Jyx2UIScripts/SkillEditorUIPanel.cs
+++ b/jyx2/Assets/Scripts/Jyx2UIScripts/SkillEditorUIPanel.cs
@@ -78,7 +78,8 @@ public partial class SkillEditorUIPanel:Jyx2_UIBase
     {
         var role = allRole[index];
         roleKey = role.Id;
-        OnSwitchModel();
+        //下面这一行会触发模型更新，这样显得按钮很没有用，所以我取消了
+        //OnSwitchModel();
     }
 
     private void OnSwitchSkillLevel(int arg0)
@@ -120,7 +121,9 @@ public partial class SkillEditorUIPanel:Jyx2_UIBase
     {
         var role = new RoleInstance(this.roleKey);
         await player.BindRoleInstance(role);
+        await player.RefreshModel();//添加这一行刷新模型
         
+        //下面两行中当前游戏使用的animator都是相同的，也许后期有其他替换animator需求？如果没有其他需求，此行应该可以不用替换？
         var animator = player.GetAnimator();
         animator.runtimeAnimatorController = player.GetComponent<Animator>().runtimeAnimatorController; //force set animator
         SwitchSkillPose();


### PR DESCRIPTION
1️⃣模型更换并不会替换模型，原因在于没有await player.RefreshModel();//添加这一行刷新模型
2️⃣测试UI中模型更换下拉框选择之后会直接更换模型，这样显得按钮很没有用，要么删除按钮，要么注释掉OnSwitchdropModelId(int index)中的OnSwitchModel();，我选择了后者。