### PR TITLE
解决在开发窗口模式下背包菜单在第二次打开后被放大的问题

### DIFF
--- a/jyx2/Assets/Prefabs/Jyx2UI/BagUIPanel.prefab
+++ b/jyx2/Assets/Prefabs/Jyx2UI/BagUIPanel.prefab
@@ -347,7 +347,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 646636080628470557}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
   m_Name: 

--- a/jyx2/Assets/Prefabs/Jyx2UI/XiakeUIPanel.prefab
+++ b/jyx2/Assets/Prefabs/Jyx2UI/XiakeUIPanel.prefab
@@ -2170,7 +2170,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 9082761885063959290}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
   m_Name: 


### PR DESCRIPTION
fix (XiakeUIPanel.prefab): 关闭CanvasScaler，解决在开发窗口模式下侠客菜单在第二次打开后被放大的问题
请参考原问题描述。开发和生产环境下（PC-Windows10）均已测试。
#850 