### PR TITLE
优化: 作弊指令AddItem减少道具时不清楚的提示信息

### DIFF
--- a/jyx2/Assets/Scripts/LuaCore/Jyx2LuaBridge.cs
+++ b/jyx2/Assets/Scripts/LuaCore/Jyx2LuaBridge.cs
@@ -1033,14 +1033,18 @@ namespace Jyx2
                     return;
                 }
 
+                var stringBuilder = new System.Text.StringBuilder();
+                var token = nameof(Jyx2LuaBridge);
+                int displayCount = Mathf.Abs(count);
                 if (count < 0)
                 {
+                    displayCount = Mathf.Min(displayCount, runtime.GetItemCount(itemId));
                     //---------------------------------------------------------------------------
                     //storyEngine.DisplayPopInfo("失去物品:" + item.Name + "×" + Math.Abs(count));
                     //---------------------------------------------------------------------------
                     //特定位置的翻译【得到物品提示】
                     //---------------------------------------------------------------------------
-                    storyEngine.DisplayPopInfo("失去物品：".GetContent(nameof(Jyx2LuaBridge)) + item.Name + "×" + Math.Abs(count));
+                    stringBuilder.Append("失去物品：".GetContent(token));
                     //---------------------------------------------------------------------------
                     //---------------------------------------------------------------------------
                 }
@@ -1051,10 +1055,14 @@ namespace Jyx2
                     //---------------------------------------------------------------------------
                     //特定位置的翻译【得到物品提示】
                     //---------------------------------------------------------------------------
-                    storyEngine.DisplayPopInfo("得到物品：".GetContent(nameof(Jyx2LuaBridge)) + item.Name + "×" + Math.Abs(count));
+                    stringBuilder.Append("得到物品：".GetContent(token));
                     //---------------------------------------------------------------------------
                     //---------------------------------------------------------------------------
                 }
+                stringBuilder.Append(item.Name);
+                stringBuilder.Append("×");
+                stringBuilder.Append(displayCount);
+                storyEngine.DisplayPopInfo(stringBuilder.ToString());
 
                 runtime.AddItem(itemId, count);
             });


### PR DESCRIPTION
close #1049 

1. 还优化了下重复连接字符串产生的gc开销。

2. 另外我看新的版本更新后在道具的数量这存了两份相同的数据，一份就是原有的```Items```字段，另一份在新加的用来时间排序的```ItemExtSaveDatas```里。一方面存档数据有点冗余，另一方面如果之后有其他逻辑来修改道具数量，不注意同时处理的话会有两份数据不同步的隐患，这部分的逻辑我建议再优化下。