### PR TITLE
优化: 优化下大地图主界面罗盘的坐标文本控件

### DIFF
--- a/jyx2/Assets/Prefabs/Jyx2UI/MainUIPanel.prefab
+++ b/jyx2/Assets/Prefabs/Jyx2UI/MainUIPanel.prefab
@@ -864,8 +864,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 150, y: 50}
-  m_SizeDelta: {x: 300, y: 100}
+  m_AnchoredPosition: {x: 161.72696, y: 45.602394}
+  m_SizeDelta: {x: 323.454, y: 91.2048}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7081709438572935240
 CanvasRenderer:

--- a/jyx2/Assets/Scripts/Jyx2UIScripts/MainUIPanel.cs
+++ b/jyx2/Assets/Scripts/Jyx2UIScripts/MainUIPanel.cs
@@ -14,6 +14,7 @@ using System.Linq;
 using Jyx2Configs;
 using System.Collections.Generic;
 using UnityEngine.UI;
+using System.Text;
 
 public partial class MainUIPanel : Jyx2_UIBase, IUIAnimator
 {
@@ -45,6 +46,9 @@ public partial class MainUIPanel : Jyx2_UIBase, IUIAnimator
 	});
 	private bool initialized;
 
+
+	private StringBuilder coordinateBuilder = new StringBuilder();
+
 	public override void Update()
 	{
 		base.Update();
@@ -58,15 +62,29 @@ public partial class MainUIPanel : Jyx2_UIBase, IUIAnimator
 		Compass.gameObject.SetActive(LevelMaster.Instance.IsInWorldMap && Jyx2LuaBridge.HaveItem(182));
 		if (Compass.gameObject.activeSelf)
 		{
-			var p = LevelMaster.Instance.GetPlayerPosition();
-			var pString = (p.x + 242).ToString("F0") + "," + (p.z + 435).ToString("F0");
-			if (!LevelMaster.Instance.GetPlayer().IsOnBoat)
+			var player = LevelMaster.Instance.GetPlayer();
+			if (player == null)
+				return;
+			coordinateBuilder.Clear();
+
+            int offsetX = 242, offsetZ = 435;
+			var playerPosition = player.transform.position;
+            coordinateBuilder.Append(Mathf.Floor(playerPosition.x + offsetX));
+            coordinateBuilder.Append(",");
+            coordinateBuilder.Append(Mathf.Floor(playerPosition.z + offsetZ));
+
+            if (!player.IsOnBoat)
 			{
-				var b = LevelMaster.Instance.GetPlayer().GetBoatPosition();
-				pString += "(" + (b.x + 242).ToString("F0") + "," + (b.z + 435).ToString("F0") + ")";
-			}
-			Compass.text = pString;
-		}
+				var boatPosition = player.GetBoatPosition();
+				coordinateBuilder.Append("(");
+				coordinateBuilder.Append(Mathf.Round(boatPosition.x + offsetX));
+				coordinateBuilder.Append(",");
+                coordinateBuilder.Append(Mathf.Round(boatPosition.z + offsetZ));
+                coordinateBuilder.Append(")");
+
+            }
+			Compass.text = coordinateBuilder.ToString();
+        }
 	}
 
 	protected override void OnShowPanel(params object[] allParams)


### PR DESCRIPTION

1.文本控件拉长点避免坐标太长导致换行（如下图的括号错位问题）
![D35DY0R}JXZVSGXV7DIAOA3](https://user-images.githubusercontent.com/25216715/191030196-924b7117-d826-4440-8ece-7708c8cad436.png)

2. 坐标字符串的拼接逻辑优化