### PR TITLE
修复：Mod加载黑屏的问题

### DIFF
--- a/jyx2/Assets/Scripts/MOD/SteamMODProvider.cs
+++ b/jyx2/Assets/Scripts/MOD/SteamMODProvider.cs
@@ -49,8 +49,8 @@ namespace Jyx2.MOD
                         });
                         if (modPaths.Count == 0)
                         {
-                            Debug.LogError("[SteamMODProvider] Mod xml file not found");
-                            return;
+                            Debug.LogWarning("[SteamMODProvider] Mod xml file not found, ModName:" + entry.Title);
+                            continue;
                         }
                         foreach (var modPath in modPaths)
                         {


### PR DESCRIPTION
Steam创意工坊订阅后，如果mod文件夹没有xml文件，读取时会直接返回掉不读后面的了，这里容错下，没有xml跳过直接读其他mod