### PR TITLE
fix issue#1316

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,3 @@
 /build_x64
 
 /.idea
-.vs/jynew/v16/Browse.VC.db
-.vs/jynew/v16/Browse.VC.db-shm
-.vs/jynew/v16/Browse.VC.db-wal
-.vs/jynew/v16/Browse.VC.opendb
-.vs/slnx.sqlite

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@
 /build_x64
 
 /.idea
+.vs/jynew/v16/Browse.VC.db
+.vs/jynew/v16/Browse.VC.db-shm
+.vs/jynew/v16/Browse.VC.db-wal
+.vs/jynew/v16/Browse.VC.opendb
+.vs/slnx.sqlite

--- a/jyx2/Assets/Scripts/GameSave/RoleInstance.cs
+++ b/jyx2/Assets/Scripts/GameSave/RoleInstance.cs
@@ -497,27 +497,6 @@ namespace Jyx2
 
             else if ((int)item.ItemType == 1 || (int)item.ItemType == 2)
             {
-                if ((int)item.ItemType == 2)
-                {
-                    //有仅适合人物，直接判断
-                    if (item.OnlySuitableRole >= 0)
-                    {
-                        return item.OnlySuitableRole == this.Key;
-                    }
-
-                    //内力属性判断
-                    if ((this.MpType == 0 || this.MpType == 1) && (item.NeedMPType == 0 || (int)item.NeedMPType == 1))
-                    {
-                        if (this.MpType != (int)item.NeedMPType)
-                        {
-                            return false;
-                        }
-                    }
-                }
-                //若有相关武学，则为真
-                //若已经学满武学，则为假
-                //满级则为真
-                //此处注意，如果有可制成物品的秘籍，则武学满级之后不会再制药了，请尽量避免这样的设置
                 if (item.Skill != null)
                 {
                     foreach (var wugong in Wugongs)
@@ -540,6 +519,28 @@ namespace Jyx2
                         return true;
                     }
                 }
+                if ((int)item.ItemType == 2)
+                {
+                    //有仅适合人物，直接判断
+                    if (item.OnlySuitableRole >= 0)
+                    {
+                        return item.OnlySuitableRole == this.Key;
+                    }
+
+                    //内力属性判断
+                    if ((this.MpType == 0 || this.MpType == 1) && (item.NeedMPType == 0 || (int)item.NeedMPType == 1))
+                    {
+                        if (this.MpType != (int)item.NeedMPType)
+                        {
+                            return false;
+                        }
+                    }
+                }
+                //若有相关武学，则为真
+                //若已经学满武学，则为假
+                //满级则为真
+                //此处注意，如果有可制成物品的秘籍，则武学满级之后不会再制药了，请尽量避免这样的设置
+
 
                 //上面的判断未确定则进入下面的判断链
                 return testAttr(this.Attack - GetWeaponProperty("Attack") - GetArmorProperty("Attack"), item.ConditionAttack)

--- a/jyx2/Assets/Scripts/GameSave/RoleInstance.cs
+++ b/jyx2/Assets/Scripts/GameSave/RoleInstance.cs
@@ -497,30 +497,21 @@ namespace Jyx2
 
             else if ((int)item.ItemType == 1 || (int)item.ItemType == 2)
             {
-                if (item.Skill != null)
-                {
+
+                if ((int)item.ItemType == 2)
+                {     
+                    int flag=0;
+                    //若有相关武学，则为真
                     foreach (var wugong in Wugongs)
                     {
                         if (wugong.Key == item.Skill)
-                            return true;
+                            flag=1;
                     }
-                    int level = GetWugongLevel(item.Skill);
-                    //if (level >= 0 && level < GameConst.MAX_WUGONG_LEVEL)
-                    //{
-                    //    return true;
-                    //}
-                    if (level < 0 && this.Wugongs.Count >= GameConst.MAX_SKILL_COUNT)
-                    {
-                        return false;
-                    }
-
-                    if (level == GameConst.MAX_WUGONG_LEVEL)
+                    if (flag == 1)
                     {
                         return true;
                     }
-                }
-                if ((int)item.ItemType == 2)
-                {
+                    //若无相关武学，开始装备条件判断
                     //有仅适合人物，直接判断
                     if (item.OnlySuitableRole >= 0)
                     {
@@ -535,11 +526,15 @@ namespace Jyx2
                             return false;
                         }
                     }
+                    int level = GetWugongLevel(item.Skill);
+                   //若已经学满武学，则为假
+                    if (level < 0 && this.Wugongs.Count >= GameConst.MAX_SKILL_COUNT)
+                    {
+                        return false;
+                    }
+
                 }
-                //若有相关武学，则为真
-                //若已经学满武学，则为假
-                //满级则为真
-                //此处注意，如果有可制成物品的秘籍，则武学满级之后不会再制药了，请尽量避免这样的设置
+
 
 
                 //上面的判断未确定则进入下面的判断链


### PR DESCRIPTION
又去看了下相关代码，发现自己对foreach理解有误好像，foreach好像是不能直接return的
```
                    foreach (var wugong in Wugongs)
                    {
                        if (wugong.Key == item.Skill)
                            return true;
                    }
```
这里的return好像无法直接返回
[同时感觉原有些地方重复判断，比如对于满级武学来说，不需要在[这里](https://github.com/jynew/jynew/blob/main/jyx2/Assets/Scripts/GameSave/RoleInstance.cs#L542)单独判断了，作为已学过武功直接安装就可以了。
同时               ` if ((int)item.ItemType == 2)`和` if (item.Skill != null)`好像都是在判断item是不是武学，然后我把这两个合并了
提交了一个新的pr，因为我还不太会进行测试，所以只能从代码层面分析，麻烦了