### PR TITLE
头像guid自动修复，临时excel删除

### DIFF
--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/0.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/0.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6619372dd50d8a0469ca86b787a7fbe4
+guid: ef25f575238f0364fb56bfc3f020e42b
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/10.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/10.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b51f33abe6d1f4b4cbdf72aa2a93acba
+guid: 33e52ca9e008bca4c9be6bf2d56c4543
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/100.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/100.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d402e60dd93ad0b448732b35150aa979
+guid: 8cad71ab65d0813409de9dcb062d35e9
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/101.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/101.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e8271487767a9844785b066eb817c900
+guid: 2336f2b2d0ea62e4b882f02fe9265db8
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/11.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/11.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 33b78d5fa92331942b6feca4e3903325
+guid: b22735cdce852484eb9e268655713bad
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/110.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/110.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 21b0ec02d6b3f8349aad9d9611c8ff69
+guid: 0f13f6a3f4383774aab3c785588949a2
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/1100.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/1100.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e9835a7d26c15284ebd14718d90e8968
+guid: 4b4fc6f9daa65f14d8d98d376b4c8cbb
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/111.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/111.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 63819c89e796d1c4eaba17896075ea94
+guid: 8bfdabc336f0a1e43b81764736725b49
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/1110.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/1110.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6985bb03aab37a145a71fa93167b87e7
+guid: 85dc528a181674742bbd53d4c01ff4af
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/1120.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/1120.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4d7d1371d310db745ab8f1b7d67569d9
+guid: c3c248ad44020524e8f2a2bdda600d74
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/1170.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/1170.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8892ccd4b039227428cab8984d88d804
+guid: fef418bd06670534f8985b86c221b222
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/1180.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/1180.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: bf3e11d3f5be9ff46b9af4566f13314b
+guid: 1eff37009d748064fa39965208e7e65c
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/1190.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/1190.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: ce843b7983cb0b149a3069cb1ed09f10
+guid: 7113e928d1796bd45b269a74b32a73b8
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/1191.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/1191.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 1ea90950d40d0d24fa7bddff724ba240
+guid: 216e21b59b47b2e4c88fd268eff342ba
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/1192.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/1192.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f8b0e6464311b4a4abdfbbf7e12c1bba
+guid: 42ccbd1d9e0a8d9439561159a5d3ee69
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/1193.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/1193.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 475ef382952baa549955540c8d8ff172
+guid: b7e86238e8f4ffc44947c7b253ffaaaa
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/1194.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/1194.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 2aa19b7be17b4fc4098641f717a6d38b
+guid: 05911dfc6681b1d4abd30ad854fb02ae
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/1195.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/1195.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 08af0b2839840a646909ec086f51930d
+guid: 6035d10fe7216444997389a0b6e93d64
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/120.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/120.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b36734c0bffd0ac4cac0af406e369515
+guid: 1747d1d10f427e24fb1218a532e7d227
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/122.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/122.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 62e9ddf4fcea6e74e86f9c37feff7a34
+guid: f8e9352e97265e74ebe9a633ca87735a
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/123.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/123.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6a785d82555c2294ba0c128d923cd9be
+guid: c7593cbbb3e9e2846bf0f6e4a6b3d069
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/130.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/130.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e77f052814d09f24b8472e48d014ee19
+guid: cd4eb2439fc559c448f38b635697539f
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/131.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/131.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4e8b4406508e5594d82963e1c7843e73
+guid: 15cf3f676b8887a4a8a5926814e23910
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/132.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/132.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 76b88b04f401ab24f9fa1639563b5865
+guid: 5bc528009cf512446a4f4c06335875af
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/140.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/140.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: da1e51e9072a5fa4a91599c6e0608f4d
+guid: 08f1e8fa1a9bf6742835e5b4c737f32b
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/141.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/141.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 09f68eadbb0e61f478394b94b8748702
+guid: 85039a4a465978e4b8581805a6502a6a
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/1410.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/1410.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8a5adc2e68886a74abc86ca06812d7f3
+guid: 1b0534201c5503f4c873d9dae85e24b2
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/142.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/142.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 1c8f3e7bb1776dc47ae08dc77948e815
+guid: e193ca082f1d2b44dae99f091b997442
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/143.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/143.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b5172a09e65931540aea06985022dd69
+guid: 3bdbcb09aa4e09c40a62084490560f32
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/144.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/144.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9d70cf0f65675e044a7f561bd8df395b
+guid: 545cb1af105b68e47b47ed6bbc5b627b
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/145.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/145.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: bbcf39d5f6993f740a6ca4bee591fbdb
+guid: 767f89892e93eef468bba2012110d62e
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/146.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/146.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d00e682249b6d4648887da2b034dd67a
+guid: dd6570a215a38074f99d0e09c91e4aab
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/147.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/147.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b759dca2b7c1d3d419b2b7cc8ba4f286
+guid: 5853583bd0e96014eb22665dc37d2baf
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/148.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/148.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 05dddc05c5ed6404593ba26baf1af1a4
+guid: fd2293d7a2656a449b5643d7db68f0b3
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/149.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/149.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c06b6128c60ed9b4ca4ba88c28c00278
+guid: 4f0d8e72cbc1585468fe04e57e59d6d2
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/150.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/150.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4b3ee6b0c5c698448b642115a70efed7
+guid: cad838fa8f577864998ac269a4a8d486
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/151.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/151.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: daedf5eed7c378f49a8e47ac2c0ac643
+guid: 30f7be1abcc3f414098c5479c9629a30
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/152.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/152.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 66ef2ddd70c080d42a8bba8438bc9c82
+guid: ad20fdd3bee2d1b498e3492dcaa68a1b
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/153.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/153.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e161229ff02b28942988332cd95710c6
+guid: c958cd26d0fa8f2468d11ff01b51f111
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/154.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/154.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4cbb521f08b98184cb8d3c1a144ddb26
+guid: 5d7809888470d684191388a436daa2d3
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/155.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/155.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 034addad16ef8e24d9218e0e926bc742
+guid: fd0820fe14ceb6c488426ff2aab78973
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/156.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/156.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: eb7af543b0b8beb4ba7f626fcd6bda48
+guid: 0778608e21757554a831355f7903043e
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/157.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/157.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 75acefc62d6ff48409a248154cba77a1
+guid: ddc5da5837dc1374680b9406e72b0b1d
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/158.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/158.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 23d3dd574c5ed06438b2e4661485a292
+guid: 7a8384414bae9ee44815295a10ae20d2
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/160.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/160.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6b2b9d0e5f229864c895ad7970d98ef4
+guid: 421fd73c54b76704581ae759e155deb7
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/161.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/161.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: ea51df4cc119c5c42bb93d56730de37f
+guid: 2c2d4110dbe412c4594ef7dbb0ce46bb
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/162.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/162.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f7282c12f8597f442a1fb4430a2b5d8c
+guid: 7f6d399d7d68bf947b1a69ec9dc84e55
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/163.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/163.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 5c27e3365ceb73b4eb7b8bc35fd95e2a
+guid: 7b38f8211bda9a243af997577e6b1496
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/164.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/164.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: cfbf6ce859e13424eac3efdd55e6e927
+guid: 402007fc9b2f0704a88e33dba054e5fc
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/165.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/165.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 71bce3c7f91993f4b929b3df8ae6cfbc
+guid: dae813bf8cd343d4e8a6e261319cebae
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/166.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/166.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d78e1a2b8e45d794f92bf2c42588419e
+guid: d6effe0157ea5af478266d8d9690e22e
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/167.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/167.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: ba7e6e268cb50584daf285796df8f82e
+guid: 71a26d5ecad9ab44380bcbab326a58ca
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/168.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/168.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: ab99a7f10342c9449842d20006e7e0a5
+guid: d9b6ce0817334d844be10e7963e556db
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/170.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/170.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 72ac5c7762f66474fb9a27f483149d6f
+guid: fe611e6c0e0a7ad4db6d91bb592d7104
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/180.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/180.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 62a5bc68c98367c4f8d9eb4f5267caa2
+guid: 455c2174519f4ca49ae4e796d0ea27a3
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/181.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/181.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 1f5d4dc3850cd03478d5a6c713afc91e
+guid: 9888c124b4d93714b8810f5088f8fd8e
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/182.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/182.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: de6b2edb3b2d42e45bc62f24d12f1a44
+guid: d9211d598c2223c4e923361241180946
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/190.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/190.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9aea90f0b47ca10459f44a340c1f497c
+guid: 5faec7adffa8d98438a7b61d9d21ca6c
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/20.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/20.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 89704f23b8f962c46a849261091a86d8
+guid: 0d4893bb9b6e19d47b830fc5f0f645a6
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/21.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/21.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f540f33f21a744d45adb7644ede86e04
+guid: 8739a2ee56b39ec4094fbb27bc234f4a
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/22.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/22.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 69b9e1d6b1d502f498064deab9818d3e
+guid: 542d7d8af5a33654997108f599fce597
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/30.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/30.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c686c35e7c8baee4ab1e3356a7e11710
+guid: 4d4f1a4b81d496448aad9b443ca1e57a
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/31.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/31.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 2528a581d849e674c890d7a94f0fd902
+guid: 06cd2508ee197ca4788db6d9ab508178
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/40.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/40.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: ad7b31f336273bd4eacb8e9507e25354
+guid: 8b1792bb4453ba149935c90d27e74f2a
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/41.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/41.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 43f22c38492e9cf4eaad7874efb2cd63
+guid: bf0b0e5d3014f1a4cb89ce969251b62e
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/42.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/42.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c22a45abfd2f7fe488eb77ea76fbdfc5
+guid: f6d01aaecc1859b46843cb4a957f993a
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/60.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/60.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e3f5e4ac059e98044af43515fcebb443
+guid: 53c2353993b266448b289b0147412524
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/61.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/61.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 624eb71a40eacd946a77688f5176564a
+guid: a76614dd586041c4bb61f1bd200b621e
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/610.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/610.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 06a2866e70301364bb956e8f3e3ebdcb
+guid: 8518e17546f40994ebe85824ce965d67
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/62.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/62.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b7d1798bf753e7a4386c12874cf6ed1c
+guid: f4adb9625e5d6924d9a0e5885a403d7b
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/70.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/70.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 1e17778e50f8b13468cffc8616d47fdd
+guid: cb845a13db16e4c448c13afa96fd8280
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/71.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/71.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 985fa91eccb452b41afd54b658f9f2a7
+guid: 822e01eec7c6e29458e7c17df343e9c2
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/72.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/72.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6441953bf41639a40a7005c635b6cdc1
+guid: 25036aff35d6ecc4690a7d56b96f71cf
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/80.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/80.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b900c887c71228742b37800d5f479788
+guid: 52df61cad40822a4ca734b61cbc13ed2
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/90.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/90.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 465448a0e41e8a847b73aaf690876580
+guid: aef06b6836d953a4fab06a502e10f4f1
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/SAMPLE/BuildSource/head/91.png.meta
+++ b/jyx2/Assets/Mods/SAMPLE/BuildSource/head/91.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: db5c14e76992748458bcd52d7c3fd324
+guid: 3d224ffa0ae80f94dbf3213cd8f1178a
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/0.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/0.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6619372dd50d8a0469ca86b787a7fbe4
+guid: c8f5849f7dc06964ea3e28c917622b7d
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/10.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/10.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b51f33abe6d1f4b4cbdf72aa2a93acba
+guid: 2c8a24a76944e3547ace82f02a08eb02
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/100.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/100.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d402e60dd93ad0b448732b35150aa979
+guid: 2f14dd62973890c438fa9c89abea09d8
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/101.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/101.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e8271487767a9844785b066eb817c900
+guid: 646ba5fbd1584424a8eb5f68636fa0f2
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/11.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/11.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 33b78d5fa92331942b6feca4e3903325
+guid: 0e964f8154f453148be13eaec8d61728
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/110.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/110.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 21b0ec02d6b3f8349aad9d9611c8ff69
+guid: 411558e28cef85945bf603b8be1f6fbb
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/1100.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/1100.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e9835a7d26c15284ebd14718d90e8968
+guid: 4888745a022e13346b2b5c805c63c436
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/111.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/111.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 63819c89e796d1c4eaba17896075ea94
+guid: b6c29464d736aac4998bef75f0f299b0
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/1110.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/1110.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6985bb03aab37a145a71fa93167b87e7
+guid: 0cd1ec7f85ff9184c814272829c75365
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/1120.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/1120.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4d7d1371d310db745ab8f1b7d67569d9
+guid: d907d6969cb1ec14d9181d15fbc80bc0
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/1170.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/1170.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8892ccd4b039227428cab8984d88d804
+guid: ce53ed1fe8c0ff948b8bd9e0ef4c7651
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/1180.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/1180.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: bf3e11d3f5be9ff46b9af4566f13314b
+guid: 74477f66dd1649448a55c1eae3ae297c
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/1190.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/1190.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: ce843b7983cb0b149a3069cb1ed09f10
+guid: bb2a2c3fe9bd677479d8a28d8c26cc33
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/1191.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/1191.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 1ea90950d40d0d24fa7bddff724ba240
+guid: 24cd8a44e9bdbe245ab1ccef7f8a7985
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/1192.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/1192.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f8b0e6464311b4a4abdfbbf7e12c1bba
+guid: 317939b1b0778524e8e33d71a23be4cc
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/1193.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/1193.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 475ef382952baa549955540c8d8ff172
+guid: b0a90505111c7894c95d103144832838
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/1194.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/1194.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 2aa19b7be17b4fc4098641f717a6d38b
+guid: 6d7dd8d26f331e44fa99f71ff2adf6a5
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/1195.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/1195.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 08af0b2839840a646909ec086f51930d
+guid: d2058a5bf154b2441b32f5d79e6b3e86
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/120.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/120.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b36734c0bffd0ac4cac0af406e369515
+guid: a5330b1e67b0f3a428539fde7ebc5ead
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/122.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/122.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 62e9ddf4fcea6e74e86f9c37feff7a34
+guid: 0f1916f8f651ae14595c474f56e8b2a6
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/123.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/123.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6a785d82555c2294ba0c128d923cd9be
+guid: 3fd67d8d72f701643b39362c5945e699
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/130.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/130.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e77f052814d09f24b8472e48d014ee19
+guid: 1dd59fe4c90a8754c93bab6dd17881dd
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/131.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/131.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4e8b4406508e5594d82963e1c7843e73
+guid: ebd60a67ab02ba54e8ad79e01b55fb3b
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/132.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/132.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 76b88b04f401ab24f9fa1639563b5865
+guid: b251dc3033595064f89a25efd71c28d1
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/140.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/140.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: da1e51e9072a5fa4a91599c6e0608f4d
+guid: 67c2627c517e6f44280195e5840964a9
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/141.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/141.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 09f68eadbb0e61f478394b94b8748702
+guid: 211635773d9ae344f8beff7e2e63e57b
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/1410.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/1410.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8a5adc2e68886a74abc86ca06812d7f3
+guid: 4ff6ec76a92e16841a4fed246b77ffe2
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/142.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/142.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 1c8f3e7bb1776dc47ae08dc77948e815
+guid: 8cba7a5af8e307249a384193ab6b4bae
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/143.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/143.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b5172a09e65931540aea06985022dd69
+guid: e9ba35063893b524abfb2d82aa7ae72d
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/144.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/144.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9d70cf0f65675e044a7f561bd8df395b
+guid: 8d140959fa4816547bd134e2b1853a60
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/145.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/145.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: bbcf39d5f6993f740a6ca4bee591fbdb
+guid: 0748861bd96ff1f43935403005c513f8
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/146.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/146.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d00e682249b6d4648887da2b034dd67a
+guid: 5441fc01e47ea934fbde05f003903e01
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/147.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/147.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b759dca2b7c1d3d419b2b7cc8ba4f286
+guid: fee64b79c6bc15d4483f5e2bc3c8a685
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/148.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/148.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 05dddc05c5ed6404593ba26baf1af1a4
+guid: 612c353a742d0bb4798c0c7b4a3d280f
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/149.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/149.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c06b6128c60ed9b4ca4ba88c28c00278
+guid: 6fbb788dc0ef7d2428825afbda711465
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/150.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/150.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4b3ee6b0c5c698448b642115a70efed7
+guid: f643325ca262f67448c2f23f753cdc6f
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/151.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/151.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: daedf5eed7c378f49a8e47ac2c0ac643
+guid: dd5710a66cf4e814da4e6cdb49ffc8ac
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/152.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/152.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 66ef2ddd70c080d42a8bba8438bc9c82
+guid: 0bb124322e079c645b7c8bc1e81e9d66
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/153.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/153.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e161229ff02b28942988332cd95710c6
+guid: e3be2c4bbad970d45be03ee20f37a0b3
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/154.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/154.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4cbb521f08b98184cb8d3c1a144ddb26
+guid: ea766af9cb196c042bf2baf41d2e3a3f
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/155.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/155.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 034addad16ef8e24d9218e0e926bc742
+guid: afd0d08ba56490d438c7f5bb52a1fd80
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/156.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/156.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: eb7af543b0b8beb4ba7f626fcd6bda48
+guid: bfd6292f645ce1849850bd2ae14a6bc4
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/157.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/157.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 75acefc62d6ff48409a248154cba77a1
+guid: 6e8f23618db116340bd58fe9c1f05a86
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/158.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/158.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 23d3dd574c5ed06438b2e4661485a292
+guid: 58f7f59ba9ecd674ca0bff0d364ffd1a
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/160.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/160.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6b2b9d0e5f229864c895ad7970d98ef4
+guid: acc51f51586680648ba83730a9657727
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/161.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/161.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: ea51df4cc119c5c42bb93d56730de37f
+guid: 5c211ab22d3f6b549b4e7fa431d68ad2
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/162.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/162.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f7282c12f8597f442a1fb4430a2b5d8c
+guid: e6879a40d8ac9634982697e1af22a02b
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/163.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/163.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 5c27e3365ceb73b4eb7b8bc35fd95e2a
+guid: 913cbd4b238e7974f93c1f8fe41a5b5d
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/164.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/164.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: cfbf6ce859e13424eac3efdd55e6e927
+guid: 347748df2e7702c42ab79070fd81647b
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/165.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/165.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 71bce3c7f91993f4b929b3df8ae6cfbc
+guid: f5d0d8aaa5b7b154a8df942bbaee9afb
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/166.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/166.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d78e1a2b8e45d794f92bf2c42588419e
+guid: 3292f8e196b06d84e9b84b51f7bdb90a
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/167.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/167.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: ba7e6e268cb50584daf285796df8f82e
+guid: c209f7ae6f882c941b2a27fb1b080b22
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/168.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/168.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: ab99a7f10342c9449842d20006e7e0a5
+guid: 72ebbd1d54f77ea4bbe5cf12f5a526b7
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/170.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/170.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 72ac5c7762f66474fb9a27f483149d6f
+guid: 86214df5bbe948e40a4f1ac6388fc6d3
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/180.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/180.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 62a5bc68c98367c4f8d9eb4f5267caa2
+guid: 4b0074201fc7ebf4c94832521577afe5
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/181.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/181.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 1f5d4dc3850cd03478d5a6c713afc91e
+guid: 6282bd71fbb4fa94aa2f68a04862612a
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/182.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/182.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: de6b2edb3b2d42e45bc62f24d12f1a44
+guid: 26505f95ac962494ba68c1fbb95f0683
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/190.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/190.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9aea90f0b47ca10459f44a340c1f497c
+guid: c350837a1c2203245a6bf273d8ef2745
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/20.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/20.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 89704f23b8f962c46a849261091a86d8
+guid: 5c95d6c8f2d90f34bb2b299acc7f9a34
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/21.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/21.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f540f33f21a744d45adb7644ede86e04
+guid: 6997c814bc750bb45ae105041504c007
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/22.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/22.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 69b9e1d6b1d502f498064deab9818d3e
+guid: 2029593d6e26da143a091b719bd6b1c5
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/30.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/30.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c686c35e7c8baee4ab1e3356a7e11710
+guid: c858e109d90c3294ebac65e9a59d0991
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/31.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/31.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 2528a581d849e674c890d7a94f0fd902
+guid: 900d726fbffdd8147aefdbbcbcbd3c1c
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/40.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/40.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: ad7b31f336273bd4eacb8e9507e25354
+guid: b16df2c2e1c90f145bf4ee93021fdb95
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/41.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/41.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 43f22c38492e9cf4eaad7874efb2cd63
+guid: c812f710a7f29004898ac58d87ca888e
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/42.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/42.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: c22a45abfd2f7fe488eb77ea76fbdfc5
+guid: 624ada6357ca17045b9cbe34647a73e6
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/60.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/60.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e3f5e4ac059e98044af43515fcebb443
+guid: d50d9f5847611c7458a6e5e23e75ee6c
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/61.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/61.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 624eb71a40eacd946a77688f5176564a
+guid: 5b90e87fd13b86745a81e5eb03d1f7ab
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/610.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/610.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 06a2866e70301364bb956e8f3e3ebdcb
+guid: f3e97998142051646a2c33337751cd13
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/62.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/62.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b7d1798bf753e7a4386c12874cf6ed1c
+guid: 83ebef60eb0f7ca48a50b042eecc50b4
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/70.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/70.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 1e17778e50f8b13468cffc8616d47fdd
+guid: afbe82cb43fcb2e48ad2d0c9341d0f77
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/71.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/71.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 985fa91eccb452b41afd54b658f9f2a7
+guid: bf8c9ac55afa69e45922753ca68b6679
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/72.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/72.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 6441953bf41639a40a7005c635b6cdc1
+guid: 9042582399d254f498c4e65bf9f37158
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/80.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/80.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b900c887c71228742b37800d5f479788
+guid: 271e6eb27ecdf474095659629cef5360
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/90.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/90.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 465448a0e41e8a847b73aaf690876580
+guid: 5bd67b86b810f2a4486eeaaed33b1959
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/91.png.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/BuildSource/head/91.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: db5c14e76992748458bcd52d7c3fd324
+guid: a5d683fe264e35448b1a0de1fbf75f62
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}

--- a/jyx2/Assets/Mods/xiastart_roguelike/Configs/~$人物.xlsx.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/Configs/~$人物.xlsx.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 7ad53e1cddb67194cb65b1135fe87fcd
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/jyx2/Assets/Mods/xiastart_roguelike/Configs/~$场景.xlsx.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/Configs/~$场景.xlsx.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: ebaffe005adaa16418bf8868e027a5b8
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/jyx2/Assets/Mods/xiastart_roguelike/Configs/~$战斗.xlsx.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/Configs/~$战斗.xlsx.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: ed549dbeb2b1dc344870113cba03889e
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/jyx2/Assets/Mods/xiastart_roguelike/Configs/~$物品.xlsx.meta
+++ b/jyx2/Assets/Mods/xiastart_roguelike/Configs/~$物品.xlsx.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: aba447f33c1bb6d4d96278b0c357229a
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
渡城的头像guid和新mod的guid是重的，unity自动修复了，临时的excel也自动删了
fix #1409