### PR TITLE
修复：在自动导航碰到Npc之后一直播放跑步动画的问题

### DIFF
--- a/jyx2/Assets/Scripts/Jyx2GameMap/PlayerControl/Jyx2_PlayerMovement.cs
+++ b/jyx2/Assets/Scripts/Jyx2GameMap/PlayerControl/Jyx2_PlayerMovement.cs
@@ -162,7 +162,10 @@ namespace Jyx2
 
         private void Update()
         {
-            IsRunning = Math.Max(m_ManualMoveSpeed, _playerNavAgent.velocity.magnitude) > 0;
+            //如果自动寻路移动速度过低，则直接停止移动
+            if (_playerNavAgent?.velocity.magnitude < 0.5f)
+                StopNavAgent();
+            IsRunning = (m_ManualMoveSpeed > 0) || (!_playerNavAgent.isStopped);
 
             //大地图待机动作计时器
             if (LevelMaster.IsInWorldMap && !_playingBigMapIdle)//只在大地图和没有在播放待机动作的时候计时


### PR DESCRIPTION
自动导航碰到npc之后，由于被npc卡住没法到达终点，会一直处于导航中，因此一直显示跑步动画
本次修复令player在自动导航移动速度小于0.5时直接停止导航